### PR TITLE
CAP-608: Report version as 3.2.5.post1.

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -1,6 +1,6 @@
 from django.utils.version import get_version
 
-VERSION = (3, 2, 5, 'final', 0)
+VERSION = (3, 2, 5, 'post', 1)
 
 __version__ = get_version(VERSION)
 

--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -33,7 +33,7 @@ def get_version(version=None):
             sub = '.dev%s' % git_changeset
 
     elif version[3] != 'final':
-        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc', 'post': 'post'}
         sub = mapping[version[3]] + str(version[4])
 
     return main + sub
@@ -55,7 +55,7 @@ def get_complete_version(version=None):
         from django import VERSION as version
     else:
         assert len(version) == 5
-        assert version[3] in ('alpha', 'beta', 'rc', 'final')
+        assert version[3] in ('alpha', 'beta', 'rc', 'final', 'post')
 
     return version
 


### PR DESCRIPTION
Report version as 3.2.5.post1.

See https://hyperscience.atlassian.net/browse/CAP-608 for some additional context. Once this is done, we'll need to rebuild the package and update the requirements files in the forms repository to use it.