### PR TITLE
Add nonclustered to supported models meta properties

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -1,6 +1,6 @@
 from django.utils.version import get_version
 
-VERSION = (3, 2, 9, 'post', 2)
+VERSION = (3, 2, 9, 'post', 3)
 
 __version__ = get_version(VERSION)
 

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -31,7 +31,9 @@ DEFAULT_NAMES = (
     'auto_created', 'index_together', 'apps', 'default_permissions',
     'select_on_save', 'default_related_name', 'required_db_features',
     'required_db_vendor', 'base_manager_name', 'default_manager_name',
-    'indexes', 'constraints', 'randomize_auto_pk',
+    'indexes', 'constraints', 'randomize_auto_pk', 'nonclustered',
+    # `randomized_auto_pk` and `nonclustered` are MSSQL backend specific.
+    # `randomized_auto_pk` implies `nonclustered`.
 )
 
 


### PR DESCRIPTION
MSSQL specific: Large high volume (inserts) tables with uuid PKs are causing excessive read IOPS when created with clustered index. We need a option to specify we want heap tables instead.

This is not needed for small tables - only once the tables pass certain size, the inserts start to read a lot (and slow down of course as well).

Related: http://www.sqlbadpractices.com/heap-tables/
`
DB2, PostreSQL, and MyISAM doesn’t even support non-heap tables. Oracle supports clustered indexes (called IOT in Oracle-speak) but defaults to heap tables.
`

And more context: https://github.com/hyperscience/forms/pull/28124