### PR TITLE
Disable auto fetching deferred fields

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -1,6 +1,6 @@
 from django.utils.version import get_version
 
-VERSION = (3, 2, 9, 'post', 3)
+VERSION = (3, 2, 9, 'post', 4)
 
 __version__ = get_version(VERSION)
 

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -8,6 +8,7 @@ circular import difficulties.
 import copy
 import functools
 import inspect
+import logging
 import warnings
 from collections import namedtuple
 
@@ -20,6 +21,8 @@ from django.utils.deprecation import RemovedInDjango40Warning
 # describe the relation in Model terms (model Options and Fields for both
 # sides of the relation. The join_field is the field backing the relation.
 PathInfo = namedtuple('PathInfo', 'from_opts to_opts target_fields join_field m2m direct filtered_relation')
+
+logger = logging.getLogger('django.db.backends')
 
 
 class InvalidQueryType(type):
@@ -141,6 +144,11 @@ class DeferredAttribute:
             # might be able to reuse the already loaded value. Refs #18343.
             val = self._check_parent_chain(instance)
             if val is None:
+                logger.error(
+                    'Trying to fetch deferred field {} for model {}. Use select_related if this is a FK otherwise '
+                    'include it in only() or remove from defer ()',
+                    field_name, str(instance.__class__)
+                )
                 instance.refresh_from_db(fields=[field_name])
             else:
                 data[field_name] = val


### PR DESCRIPTION
I would like to make usage of `only` in the queries more but it also introduces risk of making +1 query (or 1+N). There are some related feature tickets on Django reporting website:
https://code.djangoproject.com/ticket/22492
https://code.djangoproject.com/ticket/26481

And it seems to be accepted. 

Currently, I just tried this in my local as proof of concept but if people like the idea, I can actually look into changing this with FK interactions etc. Maybe even go for django contribution.

So, basically if you do
```
s = Submission.objects.only('id', 'uuid').first()
s.dt_created # This will fail
```
