### PR TITLE
[4.0.x] Fixed #33018 -- Fixed annotations with empty queryset.

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -1,6 +1,6 @@
 from django.utils.version import get_version
 
-VERSION = (3, 2, 9, 'post', 5)
+VERSION = (3, 2, 9, 'post', 6)
 
 __version__ = get_version(VERSION)
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -683,7 +683,13 @@ class Func(SQLiteNumericMixin, Expression):
         sql_parts = []
         params = []
         for arg in self.source_expressions:
-            arg_sql, arg_params = compiler.compile(arg)
+            try:
+                arg_sql, arg_params = compiler.compile(arg)
+            except EmptyResultSet:
+                empty_result_set_value = getattr(arg, 'empty_result_set_value', NotImplemented)
+                if empty_result_set_value is NotImplemented:
+                    raise
+                arg_sql, arg_params = compiler.compile(Value(empty_result_set_value))
             sql_parts.append(arg_sql)
             params.extend(arg_params)
         data = {**self.extra, **extra_context}
@@ -1091,6 +1097,7 @@ class Subquery(BaseExpression, Combinable):
     """
     template = '(%(subquery)s)'
     contains_aggregate = False
+    empty_result_set_value = None
 
     def __init__(self, queryset, output_field=None, **extra):
         # Allow the usage of both QuerySet and sql.Query objects.

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -261,8 +261,12 @@ class SQLCompiler:
             try:
                 sql, params = self.compile(col)
             except EmptyResultSet:
-                # Select a predicate that's always False.
-                sql, params = '0', ()
+                empty_result_set_value = getattr(col, 'empty_result_set_value', NotImplemented)
+                if empty_result_set_value is NotImplemented:
+                    # Select a predicate that's always False.
+                    sql, params = '0', ()
+                else:
+                    sql, params = self.compile(Value(empty_result_set_value))
             else:
                 sql, params = col.select_format(self, sql, params)
             ret.append((col, (sql, params), alias))

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -145,6 +145,7 @@ class Query(BaseExpression):
     """A single SQL query."""
 
     alias_prefix = 'T'
+    empty_result_set_value = None
     subq_aliases = frozenset([alias_prefix])
 
     compiler = 'SQLCompiler'

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -210,6 +210,12 @@ class NonAggregateAnnotationTestCase(TestCase):
         self.assertEqual(len(books), Book.objects.count())
         self.assertTrue(all(not book.selected for book in books))
 
+    def test_empty_queryset_annotation(self):
+        qs = Author.objects.annotate(
+            empty=Subquery(Author.objects.values('id').none())
+        )
+        self.assertIsNone(qs.first().empty)
+
     def test_annotate_with_aggregation(self):
         books = Book.objects.annotate(is_book=Value(1), rating_count=Count('rating'))
         for book in books:

--- a/tests/db_functions/comparison/test_coalesce.py
+++ b/tests/db_functions/comparison/test_coalesce.py
@@ -1,4 +1,4 @@
-from django.db.models import TextField
+from django.db.models import Subquery, TextField
 from django.db.models.functions import Coalesce, Lower
 from django.test import TestCase
 from django.utils import timezone
@@ -70,3 +70,14 @@ class CoalesceTests(TestCase):
             authors, ['John Smith', 'Rhonda'],
             lambda a: a.name
         )
+
+    def test_empty_queryset(self):
+        Author.objects.create(name='John Smith')
+        tests = [
+            Author.objects.none(),
+            Subquery(Author.objects.none()),
+        ]
+        for empty_query in tests:
+            with self.subTest(empty_query.__class__.__name__):
+                qs = Author.objects.annotate(annotation=Coalesce(empty_query, 42))
+                self.assertEqual(qs.first().annotation, 42)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33018
https://github.com/hyperscience/forms/pull/31800

We were hitting issues when a `Subquery` results into empty set - the value returned was `0` instead of `None` and e.g. on Oracle, for a `UUID` field, we were getting errors when the value was being processed.

Thanks Simon Charette for the review and implementation idea.

Cherry-pick of b2a0978610413e4cd5ebb716b8bfa7803dff8d5b from django:4.0.5