### PR TITLE
RER-760: default_auto_field ignored for m2m

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -227,7 +227,7 @@ class ProjectState:
 
 class AppConfigStub(AppConfig):
     """Stub of an AppConfig. Only provides a label and a dict of models."""
-    def __init__(self, label):
+    def __init__(self, label, default_af):
         self.apps = None
         self.models = {}
         # App-label and app-name are not the same thing, so technically passing
@@ -235,6 +235,7 @@ class AppConfigStub(AppConfig):
         # the app name, but we need something unique, and the label works fine.
         self.label = label
         self.name = label
+        self.default_auto_field = default_af
 
     def import_models(self):
         self.models = self.apps.all_models[self.label]
@@ -258,7 +259,7 @@ class StateApps(Apps):
                 self.real_models.append(ModelState.from_model(model, exclude_rels=True))
         # Populate the app registry with a stub for each application.
         app_labels = {model_state.app_label for model_state in models.values()}
-        app_configs = [AppConfigStub(label) for label in sorted([*real_apps, *app_labels])]
+        app_configs = [AppConfigStub(label, global_apps.get_app_config(label).default_auto_field) for label in sorted([*real_apps, *app_labels])]
         super().__init__(app_configs)
 
         # These locks get in the way of copying as implemented in clone(),
@@ -329,7 +330,7 @@ class StateApps(Apps):
     def register_model(self, app_label, model):
         self.all_models[app_label][model._meta.model_name] = model
         if app_label not in self.app_configs:
-            self.app_configs[app_label] = AppConfigStub(app_label)
+            self.app_configs[app_label] = AppConfigStub(app_label, global_apps.get_app_config(app_label).default_auto_field)
             self.app_configs[app_label].apps = self
         self.app_configs[app_label].models[model._meta.model_name] = model
         self.do_pending_operations(model)

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -227,7 +227,7 @@ class ProjectState:
 
 class AppConfigStub(AppConfig):
     """Stub of an AppConfig. Only provides a label and a dict of models."""
-    def __init__(self, label, default_af):
+    def __init__(self, label, default_auto_field):
         self.apps = None
         self.models = {}
         # App-label and app-name are not the same thing, so technically passing
@@ -235,7 +235,7 @@ class AppConfigStub(AppConfig):
         # the app name, but we need something unique, and the label works fine.
         self.label = label
         self.name = label
-        self.default_auto_field = default_af
+        self.default_auto_field = default_auto_field
 
     def import_models(self):
         self.models = self.apps.all_models[self.label]

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -119,6 +119,9 @@ class ModelBase(type):
             else:
                 app_label = app_config.label
 
+        if app_label is None:
+            app_label = getattr(meta, 'app_label', None)
+
         new_class.add_to_class('_meta', Options(meta, app_label))
         if not abstract:
             new_class.add_to_class(

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -3,6 +3,7 @@ import copy
 import inspect
 from collections import defaultdict
 
+from django.apps.registry import apps as global_apps
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
@@ -221,13 +222,20 @@ class Options:
         return new_objs
 
     def _get_default_pk_class(self):
+        app_config = self.app_config
+        if app_config is None and self.app_label:
+            try:
+                app_config = global_apps.get_app_config(self.app_label)
+            except LookupError:
+                pass
+
         pk_class_path = getattr(
-            self.app_config,
+            app_config,
             'default_auto_field',
             settings.DEFAULT_AUTO_FIELD,
         )
-        if self.app_config and self.app_config._is_default_auto_field_overridden:
-            app_config_class = type(self.app_config)
+        if app_config and app_config._is_default_auto_field_overridden:
+            app_config_class = type(app_config)
             source = (
                 f'{app_config_class.__module__}.'
                 f'{app_config_class.__qualname__}.default_auto_field'


### PR DESCRIPTION
When default_auto_field is defined on app level, it is ignored for
m2m through tables. This effectively defaults them to what is defined
in DEFAULT_AUTO_FIELD setting.

This happens in two different code paths, ulimately affecting
Options::_get_default_pk_class:
1. When AppConfigStub is supplied instead of AppConfig it is stripped
from most of the properties including default_auto_field.
2. When the first migration for a given app is applied, we don't get
any app config as it is lazily registered in StateApps::register_models.
As this is the first model for this app, the config is no there yet.